### PR TITLE
Update voxctl formula

### DIFF
--- a/Formula/voxctl.rb
+++ b/Formula/voxctl.rb
@@ -3,10 +3,13 @@ class Voxctl < Formula
   homepage "https://github.com/majjoha/voxctl"
   url "https://github.com/majjoha/voxctl/archive/v1.1.0.tar.gz"
   sha256 "f26d7377dcdfeff9e7e0a807dcbfff6e90631a83832a9e35561e7be910a8c0c4"
-  version "1.1.0"
+  license "ISC"
+  head "https://github.com/majjoha/voxctl.git"
+
+  bottle :uneeded
 
   def install
     bin.install "voxctl"
-    zsh_completion.install "share/zsh/site-functions/_voxctl" => "_voxctl"
+    zsh_completion.install "contrib/completion/_voxctl"
   end
 end


### PR DESCRIPTION
MIrroring changes from https://github.com/majjoha/voxctl/pull/2

Other changes:
- adding license
- implicit version (extracted from `url`)
- enabling install from git `HEAD`
- adding `bottle :uneeded`